### PR TITLE
feat: Add AI platform deep links for optimized prompts

### DIFF
--- a/DEEP_LINKS_DEMO.md
+++ b/DEEP_LINKS_DEMO.md
@@ -1,0 +1,76 @@
+# AI Platform Deep Links Demo
+
+This feature adds "Open in" buttons alongside the copy functionality, allowing users to click and directly open AI platforms with their optimized prompts.
+
+## What's New
+
+### ChatGPT Deep Link
+- **URL Format**: `https://chat.openai.com/?q=<encoded_prompt>`
+- **Behavior**: Opens ChatGPT with the prompt pre-filled
+- **Requirement**: Requires "Prompt ChatGPT via URL param" Chrome extension for auto-submit
+- **Visual Indicator**: Shows "*" symbol and disclaimer about extension requirement
+
+### Other Platforms
+- **Claude**: Opens `https://claude.ai/` (no deep link support, user pastes manually)
+- **Gemini**: Opens `https://gemini.google.com/` (no deep link support, user pastes manually)  
+- **Perplexity**: Opens `https://perplexity.ai/` (no deep link support, user pastes manually)
+
+## Usage Flow
+
+1. User enters prompt and clicks "Refine Prompt"
+2. PromptDial optimizes the prompt
+3. Results show both:
+   - **Copy button**: Traditional copy-to-clipboard
+   - **Open in buttons**: Direct links to AI platforms
+4. User clicks "ChatGPT" button → Browser opens ChatGPT with prompt pre-filled
+5. User clicks other platform buttons → Browser opens platform's main interface
+
+## Technical Implementation
+
+### Core Components
+
+1. **`/utils/deepLinks.ts`** - Utility functions for generating platform URLs
+2. **`/components/DeepLinkButtons/`** - Reusable component for rendering platform buttons  
+3. **Integration** - Added to `ResultsList` and `OptimizedPromptViewer` components
+
+### URL Encoding
+All prompts are properly URL-encoded using `encodeURIComponent()` to handle:
+- Special characters (&, =, ?, #)
+- Spaces and line breaks
+- Unicode characters
+
+### Browser Security
+- Links open with `window.open(url, '_blank', 'noopener,noreferrer')`
+- Prevents opener access and referrer leakage
+- Safe handling of user-generated content
+
+## User Experience
+
+### Before
+1. Click copy
+2. Open ChatGPT in new tab  
+3. Paste and submit prompt
+
+### After (with extension)
+1. Click "ChatGPT" button
+2. Browser opens ChatGPT and auto-submits optimized prompt
+
+### Visual Design
+- Buttons use emojis for platform recognition (🤖 🔮 💎 🔍)
+- Extension-required buttons shown with dashed border and warning color
+- Responsive design works on mobile and desktop
+- Dark mode support included
+
+## Testing
+
+- ✅ Unit tests for utility functions
+- ✅ Component tests for button rendering and click behavior
+- ✅ URL encoding verification with special characters
+- ✅ TypeScript compilation without errors
+
+## Browser Extension Info
+
+The ChatGPT deep link functionality requires the "Prompt ChatGPT via URL param" extension:
+- Available on Chrome Web Store
+- Automatically submits prompts when URL contains `?q=` parameter
+- Without extension, ChatGPT opens but user must manually submit prompt

--- a/packages/ui/src/components/DeepLinkButtons/DeepLinkButtons.module.css
+++ b/packages/ui/src/components/DeepLinkButtons/DeepLinkButtons.module.css
@@ -1,0 +1,134 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #6b7280;
+  margin-bottom: 0.25rem;
+}
+
+.buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.linkButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.5rem 0.75rem;
+  background: #f3f4f6;
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+  color: #374151;
+  text-decoration: none;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  position: relative;
+}
+
+.linkButton:hover {
+  background: #e5e7eb;
+  border-color: #9ca3af;
+  transform: translateY(-1px);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.linkButton:active {
+  transform: translateY(0);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+.linkButton:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+  border-color: #3b82f6;
+}
+
+.requiresExtension {
+  border-style: dashed;
+  background: #fef3c7;
+  color: #92400e;
+  border-color: #fbbf24;
+}
+
+.requiresExtension:hover {
+  background: #fde68a;
+  border-color: #f59e0b;
+}
+
+.icon {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.name {
+  white-space: nowrap;
+}
+
+.extensionIndicator {
+  color: #f59e0b;
+  font-weight: bold;
+  font-size: 0.75rem;
+  margin-left: 0.125rem;
+}
+
+.disclaimer {
+  font-size: 0.75rem;
+  color: #6b7280;
+  font-style: italic;
+  margin-top: 0.25rem;
+}
+
+/* Responsive design */
+@media (max-width: 640px) {
+  .buttons {
+    flex-direction: column;
+  }
+  
+  .linkButton {
+    justify-content: center;
+    width: 100%;
+  }
+}
+
+/* Dark mode support */
+@media (prefers-color-scheme: dark) {
+  .label {
+    color: #9ca3af;
+  }
+  
+  .linkButton {
+    background: #374151;
+    border-color: #4b5563;
+    color: #f9fafb;
+  }
+  
+  .linkButton:hover {
+    background: #4b5563;
+    border-color: #6b7280;
+  }
+  
+  .requiresExtension {
+    background: #451a03;
+    color: #fbbf24;
+    border-color: #92400e;
+  }
+  
+  .requiresExtension:hover {
+    background: #78350f;
+    border-color: #b45309;
+  }
+  
+  .disclaimer {
+    color: #9ca3af;
+  }
+}

--- a/packages/ui/src/components/DeepLinkButtons/DeepLinkButtons.test.tsx
+++ b/packages/ui/src/components/DeepLinkButtons/DeepLinkButtons.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { DeepLinkButtons } from './DeepLinkButtons'
+
+// Mock window.open
+const mockWindowOpen = vi.fn()
+Object.defineProperty(window, 'open', {
+  value: mockWindowOpen,
+  writable: true
+})
+
+describe('DeepLinkButtons', () => {
+  beforeEach(() => {
+    mockWindowOpen.mockClear()
+  })
+
+  it('renders all platform buttons', () => {
+    const testPrompt = 'Test prompt for AI'
+    render(<DeepLinkButtons prompt={testPrompt} />)
+    
+    expect(screen.getByRole('button', { name: /open prompt in chatgpt/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /open prompt in claude/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /open prompt in gemini/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /open prompt in perplexity/i })).toBeInTheDocument()
+  })
+
+  it('shows extension indicator for ChatGPT', () => {
+    render(<DeepLinkButtons prompt="test" />)
+    
+    const chatgptButton = screen.getByRole('button', { name: /open prompt in chatgpt/i })
+    expect(chatgptButton.className).toContain('requiresExtension')
+    expect(screen.getByText('*')).toBeInTheDocument()
+    expect(screen.getByText('* Requires browser extension for auto-submit')).toBeInTheDocument()
+  })
+
+  it('opens ChatGPT with encoded prompt when clicked', () => {
+    const testPrompt = 'Hello, test prompt with spaces!'
+    render(<DeepLinkButtons prompt={testPrompt} />)
+    
+    const chatgptButton = screen.getByRole('button', { name: /open prompt in chatgpt/i })
+    fireEvent.click(chatgptButton)
+    
+    const expectedUrl = `https://chat.openai.com/?q=${encodeURIComponent(testPrompt)}`
+    expect(mockWindowOpen).toHaveBeenCalledWith(expectedUrl, '_blank', 'noopener,noreferrer')
+  })
+
+  it('opens Claude with base URL when clicked', () => {
+    render(<DeepLinkButtons prompt="test prompt" />)
+    
+    const claudeButton = screen.getByRole('button', { name: /open prompt in claude/i })
+    fireEvent.click(claudeButton)
+    
+    expect(mockWindowOpen).toHaveBeenCalledWith('https://claude.ai/', '_blank', 'noopener,noreferrer')
+  })
+
+  it('handles special characters in prompts correctly', () => {
+    const specialPrompt = 'Test with special characters: &=?#'
+    render(<DeepLinkButtons prompt={specialPrompt} />)
+    
+    const chatgptButton = screen.getByRole('button', { name: /open prompt in chatgpt/i })
+    fireEvent.click(chatgptButton)
+    
+    const expectedUrl = `https://chat.openai.com/?q=${encodeURIComponent(specialPrompt)}`
+    expect(mockWindowOpen).toHaveBeenCalledWith(expectedUrl, '_blank', 'noopener,noreferrer')
+  })
+
+  it('applies custom className when provided', () => {
+    const { container } = render(<DeepLinkButtons prompt="test" className="custom-class" />)
+    
+    expect(container.firstChild).toHaveClass('custom-class')
+  })
+})

--- a/packages/ui/src/components/DeepLinkButtons/DeepLinkButtons.tsx
+++ b/packages/ui/src/components/DeepLinkButtons/DeepLinkButtons.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import { getAllPlatformLinks, type PlatformLink } from '@/utils/deepLinks'
+import styles from './DeepLinkButtons.module.css'
+
+interface DeepLinkButtonsProps {
+  prompt: string
+  model?: string
+  className?: string
+}
+
+export function DeepLinkButtons({ prompt, model, className }: DeepLinkButtonsProps) {
+  const links = getAllPlatformLinks(prompt)
+
+  const handleLinkClick = (link: PlatformLink) => {
+    window.open(link.url, '_blank', 'noopener,noreferrer')
+  }
+
+  return (
+    <div className={`${styles.container} ${className || ''}`}>
+      <div className={styles.label}>Open in:</div>
+      <div className={styles.buttons}>
+        {links.map((link) => (
+          <button
+            key={link.name}
+            className={`${styles.linkButton} ${link.requiresExtension ? styles.requiresExtension : ''}`}
+            onClick={() => handleLinkClick(link)}
+            title={link.requiresExtension ? `${link.name} (requires browser extension)` : `Open in ${link.name}`}
+            aria-label={`Open prompt in ${link.name}`}
+          >
+            <span className={styles.icon} aria-hidden="true">
+              {link.icon}
+            </span>
+            <span className={styles.name}>{link.name}</span>
+            {link.requiresExtension && (
+              <span className={styles.extensionIndicator} aria-label="requires extension">
+                *
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+      {links.some(link => link.requiresExtension) && (
+        <div className={styles.disclaimer}>
+          * Requires browser extension for auto-submit
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/ui/src/components/DeepLinkButtons/index.ts
+++ b/packages/ui/src/components/DeepLinkButtons/index.ts
@@ -1,0 +1,1 @@
+export { DeepLinkButtons } from './DeepLinkButtons'

--- a/packages/ui/src/components/OptimizedPromptViewer.tsx
+++ b/packages/ui/src/components/OptimizedPromptViewer.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { DeepLinkButtons } from './DeepLinkButtons'
 
 interface OptimizedPromptViewerProps {
   variants: Array<{
@@ -35,6 +36,7 @@ export function OptimizedPromptViewer({ variants, bestIndex }: OptimizedPromptVi
         <button onClick={handleCopy} className="copy-button">
           {copied ? '✅ Copied!' : '📋 Copy'}
         </button>
+        <DeepLinkButtons prompt={bestVariant.variant} />
       </div>
 
       {variants.length > 1 && (

--- a/packages/ui/src/components/ResultsList/ResultsList.module.css
+++ b/packages/ui/src/components/ResultsList/ResultsList.module.css
@@ -147,6 +147,12 @@
   height: 14px;
 }
 
+.deepLinkSection {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid #e5e7eb;
+}
+
 
 @media (max-width: 768px) {
   .emptyState {

--- a/packages/ui/src/components/ResultsList/ResultsList.tsx
+++ b/packages/ui/src/components/ResultsList/ResultsList.tsx
@@ -1,5 +1,6 @@
 import type { OptimizedResult } from '@/types'
 import { LoadingSpinner, ErrorMessage, LiveRegion } from '@/components/common'
+import { DeepLinkButtons } from '@/components/DeepLinkButtons'
 import styles from './ResultsList.module.css'
 
 interface ResultsListProps {
@@ -93,6 +94,12 @@ export function ResultsList({ isLoading, results, error, onCopy }: ResultsListPr
             Copy
           </button>
         </div>
+
+        {/* Deep Link Buttons */}
+        <DeepLinkButtons 
+          prompt={bestVariant.optimizedPrompt}
+          className={styles.deepLinkSection}
+        />
       </div>
     </div>
   )

--- a/packages/ui/src/utils/deepLinks.test.ts
+++ b/packages/ui/src/utils/deepLinks.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest'
+import { 
+  getChatGPTLink, 
+  getClaudeLink, 
+  getGeminiLink, 
+  getPerplexityLink,
+  getAllPlatformLinks,
+  getPlatformLinksForModel 
+} from './deepLinks'
+
+describe('deepLinks utilities', () => {
+  const testPrompt = 'Test prompt with spaces and special chars: &=?#'
+
+  describe('getChatGPTLink', () => {
+    it('returns correct ChatGPT link with encoded prompt', () => {
+      const result = getChatGPTLink(testPrompt)
+      
+      expect(result.name).toBe('ChatGPT')
+      expect(result.url).toBe(`https://chat.openai.com/?q=${encodeURIComponent(testPrompt)}`)
+      expect(result.requiresExtension).toBe(true)
+      expect(result.icon).toBe('🤖')
+    })
+
+    it('handles empty prompt', () => {
+      const result = getChatGPTLink('')
+      expect(result.url).toBe('https://chat.openai.com/?q=')
+    })
+  })
+
+  describe('getClaudeLink', () => {
+    it('returns correct Claude link', () => {
+      const result = getClaudeLink()
+      
+      expect(result.name).toBe('Claude')
+      expect(result.url).toBe('https://claude.ai/')
+      expect(result.requiresExtension).toBe(false)
+      expect(result.icon).toBe('🔮')
+    })
+  })
+
+  describe('getGeminiLink', () => {
+    it('returns correct Gemini link', () => {
+      const result = getGeminiLink()
+      
+      expect(result.name).toBe('Gemini')
+      expect(result.url).toBe('https://gemini.google.com/')
+      expect(result.requiresExtension).toBe(false)
+      expect(result.icon).toBe('💎')
+    })
+  })
+
+  describe('getPerplexityLink', () => {
+    it('returns correct Perplexity link', () => {
+      const result = getPerplexityLink()
+      
+      expect(result.name).toBe('Perplexity')
+      expect(result.url).toBe('https://perplexity.ai/')
+      expect(result.requiresExtension).toBe(false)
+      expect(result.icon).toBe('🔍')
+    })
+  })
+
+  describe('getAllPlatformLinks', () => {
+    it('returns all platform links', () => {
+      const result = getAllPlatformLinks(testPrompt)
+      
+      expect(result).toHaveLength(4)
+      expect(result.map(link => link.name)).toEqual(['ChatGPT', 'Claude', 'Gemini', 'Perplexity'])
+    })
+
+    it('includes encoded prompt in ChatGPT link only', () => {
+      const result = getAllPlatformLinks(testPrompt)
+      
+      const chatgptLink = result.find(link => link.name === 'ChatGPT')
+      expect(chatgptLink?.url).toContain(encodeURIComponent(testPrompt))
+      
+      const otherLinks = result.filter(link => link.name !== 'ChatGPT')
+      otherLinks.forEach(link => {
+        expect(link.url).not.toContain(encodeURIComponent(testPrompt))
+      })
+    })
+  })
+
+  describe('getPlatformLinksForModel', () => {
+    it('returns ChatGPT and Perplexity for GPT models', () => {
+      const result = getPlatformLinksForModel(testPrompt, 'gpt-4')
+      
+      expect(result).toHaveLength(2)
+      expect(result.map(link => link.name)).toEqual(['ChatGPT', 'Perplexity'])
+    })
+
+    it('returns Claude and Perplexity for Claude models', () => {
+      const result = getPlatformLinksForModel(testPrompt, 'claude-3-opus')
+      
+      expect(result).toHaveLength(2)
+      expect(result.map(link => link.name)).toEqual(['Claude', 'Perplexity'])
+    })
+
+    it('returns Gemini and Perplexity for Gemini models', () => {
+      const result = getPlatformLinksForModel(testPrompt, 'gemini-pro')
+      
+      expect(result).toHaveLength(2)
+      expect(result.map(link => link.name)).toEqual(['Gemini', 'Perplexity'])
+    })
+
+    it('returns default platforms for unknown models', () => {
+      const result = getPlatformLinksForModel(testPrompt, 'unknown-model')
+      
+      expect(result).toHaveLength(3)
+      expect(result.map(link => link.name)).toEqual(['ChatGPT', 'Claude', 'Gemini'])
+    })
+  })
+})

--- a/packages/ui/src/utils/deepLinks.ts
+++ b/packages/ui/src/utils/deepLinks.ts
@@ -1,0 +1,97 @@
+/**
+ * Utility functions for generating deep links to AI platforms with pre-filled prompts
+ */
+
+export interface PlatformLink {
+  name: string
+  url: string
+  requiresExtension?: boolean
+  icon: string
+}
+
+/**
+ * Generates a deep link to ChatGPT with a pre-filled prompt
+ * Note: Requires "Prompt ChatGPT via URL param" Chrome extension for auto-submit
+ */
+export function getChatGPTLink(prompt: string): PlatformLink {
+  const encodedPrompt = encodeURIComponent(prompt)
+  return {
+    name: 'ChatGPT',
+    url: `https://chat.openai.com/?q=${encodedPrompt}`,
+    requiresExtension: true,
+    icon: '🤖'
+  }
+}
+
+/**
+ * Generates a link to Claude AI
+ * Note: No deep link support, opens main interface where user can paste
+ */
+export function getClaudeLink(): PlatformLink {
+  return {
+    name: 'Claude',
+    url: 'https://claude.ai/',
+    requiresExtension: false,
+    icon: '🔮'
+  }
+}
+
+/**
+ * Generates a link to Google Gemini
+ * Note: No deep link support, opens main interface where user can paste
+ */
+export function getGeminiLink(): PlatformLink {
+  return {
+    name: 'Gemini',
+    url: 'https://gemini.google.com/',
+    requiresExtension: false,
+    icon: '💎'
+  }
+}
+
+/**
+ * Generates a link to Perplexity AI
+ * Note: No deep link support, opens main interface where user can paste
+ */
+export function getPerplexityLink(): PlatformLink {
+  return {
+    name: 'Perplexity',
+    url: 'https://perplexity.ai/',
+    requiresExtension: false,
+    icon: '🔍'
+  }
+}
+
+/**
+ * Gets all available platform links for a prompt
+ */
+export function getAllPlatformLinks(prompt: string): PlatformLink[] {
+  return [
+    getChatGPTLink(prompt),
+    getClaudeLink(),
+    getGeminiLink(),
+    getPerplexityLink()
+  ]
+}
+
+/**
+ * Gets platform links based on the target model from PromptDial optimization
+ */
+export function getPlatformLinksForModel(prompt: string, model: string): PlatformLink[] {
+  const allLinks = getAllPlatformLinks(prompt)
+  
+  // Map model names to platform preferences
+  const modelToPlatform: Record<string, string[]> = {
+    'gpt-4': ['ChatGPT', 'Perplexity'],
+    'gpt-4o': ['ChatGPT', 'Perplexity'],
+    'claude-3-opus': ['Claude', 'Perplexity'],
+    'claude-3-sonnet': ['Claude', 'Perplexity'],
+    'claude-3-haiku': ['Claude', 'Perplexity'],
+    'gemini-pro': ['Gemini', 'Perplexity'],
+    'gemini-ultra': ['Gemini', 'Perplexity']
+  }
+  
+  const preferredPlatforms = modelToPlatform[model] || ['ChatGPT', 'Claude', 'Gemini']
+  
+  return allLinks.filter(link => preferredPlatforms.includes(link.name))
+}


### PR DESCRIPTION
## Summary
- Implement one-click deep links to open optimized prompts directly in AI platforms
- Add "Open in" buttons alongside the existing copy functionality in the UI
- Support ChatGPT deep links with URL-encoded prompts (requires browser extension)

## Motivation
Currently, users need to:
1. Click copy button
2. Open ChatGPT/Claude/etc in a new tab
3. Paste and submit the prompt

With this feature, it's just:
1. Click "Open in ChatGPT" → Browser opens with optimized prompt ready\!

## Changes
- Added `deepLinks.ts` utility for generating platform-specific URLs
- Created reusable `DeepLinkButtons` component with platform icons
- Integrated deep links into `ResultsList` and `OptimizedPromptViewer`
- Added comprehensive tests for URL encoding and component behavior

## Platform Support
- **ChatGPT**: Deep link with `?q=<encoded_prompt>` parameter (requires "Prompt ChatGPT via URL param" Chrome extension)
- **Claude, Gemini, Perplexity**: Direct platform links (user pastes manually)

## Visual Design
- Platform-specific emoji icons for quick recognition
- Dashed border and warning color for extension-required buttons
- Responsive layout that works on mobile and desktop
- Dark mode support included

## Testing
- ✅ 11/11 utility function tests passing
- ✅ Component tests for rendering and click behavior  
- ✅ URL encoding verified with special characters
- ✅ TypeScript compilation without errors

## Demo
See `DEEP_LINKS_DEMO.md` for detailed documentation and usage examples.

🤖 Generated with [Claude Code](https://claude.ai/code)