### PR TITLE
Fix: Correct public directory path in server.ts

### DIFF
--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -16,7 +16,7 @@ app.use(cors())
 app.use(express.json())
 
 // Serve static files from public directory
-const publicPath = path.join(__dirname, '../../../public')
+const publicPath = path.join(__dirname, '../../../tianjin/public')
 app.use(express.static(publicPath))
 
 // Server-Sent Events endpoint for real-time progress


### PR DESCRIPTION
## Summary
- Fixed ENOENT error when serving static files from public directory
- Updated path from `../../../public` to `../../../tianjin/public` to match actual directory structure

## Test plan
- [ ] Verify server starts without ENOENT error
- [ ] Verify index.html is served correctly at root path
- [ ] Verify static assets are accessible

🤖 Generated with [Claude Code](https://claude.ai/code)