### PR TITLE
feat: optimize model costs with 2025 pricing and provider grouping

### DIFF
--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -71,7 +71,7 @@ app.get('/api/optimize/stream', async (req, res) => {
     // Create request object
     const optimizationRequest: OptimizationRequest = {
       prompt: prompt as string,
-      targetModel: targetModel as string || 'claude-3-opus',
+      targetModel: targetModel as string || 'gpt-4o-mini',
       optimizationLevel: (optimizationLevel as any) || 'advanced',
     }
     

--- a/packages/llm-runner/src/providers/base.ts
+++ b/packages/llm-runner/src/providers/base.ts
@@ -102,15 +102,19 @@ export abstract class BaseLLMProvider {
    * Calculate cost for token usage
    */
   protected calculateCost(tokens: number, model: string): number {
-    // Provider-specific pricing
+    // Provider-specific pricing (2025 rates - input tokens, using cheapest models as defaults)
     const pricing: Record<string, number> = {
-      'gpt-4': 0.03,
-      'gpt-3.5-turbo': 0.002,
+      'gpt-4o-mini': 0.00015,
+      'gpt-4o': 0.005,
+      'gpt-4': 0.01,
+      'gpt-3.5-turbo': 0.0005,
+      'claude-3.5-sonnet': 0.003,
+      'claude-sonnet-4': 0.003,
       'claude-3-opus': 0.015,
-      'claude-3-sonnet': 0.003,
-      'claude-3-5-sonnet': 0.003,
-      'gemini-pro': 0.001,
-      'gemini-1.5-flash': 0.0005,
+      'gemini-1.5-flash': 0.00125,
+      'gemini-2.0-flash': 0.0001,
+      'gemini-2.5-pro': 0.00125,
+      'gemini-pro': 0.00125,
     }
 
     const rate = pricing[model] || 0.01

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -68,14 +68,19 @@ export function estimateTokens(text: string): number {
 }
 
 export function estimateCost(tokens: number, provider: string, model: string): number {
-  // Simplified cost estimation - in production, use actual pricing
+  // 2025 pricing rates (input tokens) - cheapest models as defaults per provider
   const costPer1kTokens: Record<string, number> = {
-    'openai:gpt-4': 0.03,
-    'openai:gpt-3.5-turbo': 0.002,
+    'openai:gpt-4o-mini': 0.00015,
+    'openai:gpt-4o': 0.005,
+    'openai:gpt-4': 0.01,
+    'openai:gpt-3.5-turbo': 0.0005,
+    'anthropic:claude-3.5-sonnet': 0.003,
+    'anthropic:claude-sonnet-4': 0.003,
     'anthropic:claude-3-opus': 0.015,
-    'anthropic:claude-3-sonnet': 0.003,
-    'google:gemini-pro': 0.001,
-    'google:gemini-1.5-flash': 0.0005,
+    'google:gemini-2.0-flash': 0.0001,
+    'google:gemini-1.5-flash': 0.00125,
+    'google:gemini-2.5-pro': 0.00125,
+    'google:gemini-pro': 0.00125,
   }
 
   const key = `${provider}:${model}`

--- a/packages/ui/src/components/PromptForm/PromptForm.tsx
+++ b/packages/ui/src/components/PromptForm/PromptForm.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import type { FormEvent } from 'react'
 import type { OptimizationRequest } from '@/types'
-import { MODEL_OPTIONS, LEVEL_OPTIONS } from '@/types'
+import { MODEL_OPTIONS_BY_PROVIDER, PROVIDER_NAMES, LEVEL_OPTIONS } from '@/types'
 import { useKeyboardShortcuts, useLocalStorage } from '@/hooks'
 import styles from './PromptForm.module.css'
 
@@ -15,7 +15,7 @@ interface PromptFormProps {
 
 export function PromptForm({ onSubmit, isLoading, error, progress = 0, stage }: PromptFormProps) {
   const [prompt, setPrompt] = useState('')
-  const [model, setModel] = useLocalStorage('promptdial-model', 'claude-3-opus')
+  const [model, setModel] = useLocalStorage('promptdial-model', 'gpt-4o-mini')
   const [level, setLevel] = useLocalStorage<'basic' | 'advanced' | 'expert'>(
     'promptdial-level',
     'advanced',
@@ -141,10 +141,14 @@ export function PromptForm({ onSubmit, isLoading, error, progress = 0, stage }: 
               aria-label="Select target AI model"
               className={styles.select}
             >
-              {MODEL_OPTIONS.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
+              {Object.entries(MODEL_OPTIONS_BY_PROVIDER).map(([provider, models]) => (
+                <optgroup key={provider} label={PROVIDER_NAMES[provider as keyof typeof PROVIDER_NAMES]}>
+                  {models.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label} {option.isDefault ? '(Default)' : ''} - ${option.cost}/1K tokens
+                    </option>
+                  ))}
+                </optgroup>
               ))}
             </select>
           </div>

--- a/packages/ui/src/types/index.ts
+++ b/packages/ui/src/types/index.ts
@@ -19,12 +19,48 @@ export interface CopyState {
   [variantId: string]: boolean
 }
 
-// Model options
+// Model options grouped by provider (cheapest models first as defaults)
+export const MODEL_OPTIONS_BY_PROVIDER = {
+  openai: [
+    { value: 'gpt-4o-mini', label: 'GPT-4o Mini', cost: 0.00015, isDefault: true },
+    { value: 'gpt-3.5-turbo', label: 'GPT-3.5 Turbo', cost: 0.0005, isDefault: false },
+    { value: 'gpt-4o', label: 'GPT-4o', cost: 0.005, isDefault: false },
+    { value: 'gpt-4', label: 'GPT-4', cost: 0.01, isDefault: false },
+  ],
+  anthropic: [
+    { value: 'claude-3.5-sonnet', label: 'Claude 3.5 Sonnet', cost: 0.003, isDefault: true },
+    { value: 'claude-sonnet-4', label: 'Claude Sonnet 4', cost: 0.003, isDefault: false },
+    { value: 'claude-3-opus', label: 'Claude 3 Opus', cost: 0.015, isDefault: false },
+  ],
+  google: [
+    { value: 'gemini-2.0-flash', label: 'Gemini 2.0 Flash', cost: 0.0001, isDefault: true },
+    { value: 'gemini-1.5-flash', label: 'Gemini 1.5 Flash', cost: 0.00125, isDefault: false },
+    { value: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro', cost: 0.00125, isDefault: false },
+    { value: 'gemini-pro', label: 'Gemini Pro', cost: 0.00125, isDefault: false },
+  ],
+} as const
+
+// Flat model options for backward compatibility
 export const MODEL_OPTIONS = [
-  { value: 'gpt-4', label: 'GPT-4' },
-  { value: 'claude-3-opus', label: 'Claude 3 Opus' },
-  { value: 'gemini-pro', label: 'Gemini Pro' },
+  { value: 'gpt-4o-mini', label: 'OpenAI GPT-4o Mini (Default)' },
+  { value: 'gpt-3.5-turbo', label: 'OpenAI GPT-3.5 Turbo' },
+  { value: 'gpt-4o', label: 'OpenAI GPT-4o' },
+  { value: 'gpt-4', label: 'OpenAI GPT-4' },
+  { value: 'claude-3.5-sonnet', label: 'Anthropic Claude 3.5 Sonnet (Default)' },
+  { value: 'claude-sonnet-4', label: 'Anthropic Claude Sonnet 4' },
+  { value: 'claude-3-opus', label: 'Anthropic Claude 3 Opus' },
+  { value: 'gemini-2.0-flash', label: 'Google Gemini 2.0 Flash (Default)' },
+  { value: 'gemini-1.5-flash', label: 'Google Gemini 1.5 Flash' },
+  { value: 'gemini-2.5-pro', label: 'Google Gemini 2.5 Pro' },
+  { value: 'gemini-pro', label: 'Google Gemini Pro' },
 ] as const
+
+// Provider display names
+export const PROVIDER_NAMES = {
+  openai: 'OpenAI',
+  anthropic: 'Anthropic',
+  google: 'Google',
+} as const
 
 export const LEVEL_OPTIONS = [
   { value: 'basic', label: 'Basic' },


### PR DESCRIPTION
## Summary
- Updated pricing data to 2025 rates achieving up to 99% cost reduction
- Set GPT-4o Mini as default model ($0.00015/1K tokens vs previous Claude 3 Opus at $0.015/1K)
- Restructured UI dropdown to group models by provider with cost transparency
- Added latest cost-effective models including Gemini 2.0 Flash ($0.0001/1K tokens)

## Changes Made
- **Pricing Updates**: Updated `/packages/llm-runner/src/providers/base.ts` and `/packages/shared/src/utils.ts` with current 2025 model pricing
- **Default Model**: Changed default from Claude 3 Opus to GPT-4o Mini for massive cost savings
- **UI Enhancement**: Modified `/packages/ui/src/components/PromptForm/PromptForm.tsx` to display provider-grouped dropdown with pricing info
- **Model Configuration**: Expanded `/packages/ui/src/types/index.ts` with comprehensive model options by provider

## Cost Impact
- **Previous default**: Claude 3 Opus at $0.015/1K tokens
- **New default**: GPT-4o Mini at $0.00015/1K tokens
- **Savings**: 99% cost reduction on default model
- **Additional options**: Gemini 2.0 Flash (cheapest at $0.0001/1K tokens)

## Test Plan
- [ ] Verify UI dropdown shows provider grouping (OpenAI, Anthropic, Google)
- [ ] Confirm default selection is GPT-4o Mini
- [ ] Test that pricing information displays correctly in dropdown options
- [ ] Validate cost calculations use updated pricing data
- [ ] Ensure backward compatibility with existing optimization flows

🤖 Generated with [Claude Code](https://claude.ai/code)