### PR TITLE
feat: remove redundant Chain-of-Thought UI toggle

### DIFF
--- a/packages/core/public/index.html
+++ b/packages/core/public/index.html
@@ -512,17 +512,6 @@
                     </div>
                 </div>
                 
-                <!-- Toggle Switch -->
-                <div class="toggle-group">
-                    <div class="toggle-label">
-                        <span>Chain-of-Thought</span>
-                        <span class="badge">Advanced</span>
-                    </div>
-                    <div class="toggle-switch" id="toggleCot">
-                        <input type="checkbox" id="chainOfThought" name="chainOfThought">
-                        <span class="toggle-slider"></span>
-                    </div>
-                </div>
                 
                 <button type="submit" class="button" id="optimizeBtn">
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
@@ -557,15 +546,8 @@
         const resultsDiv = document.getElementById('results');
         const readyState = document.getElementById('readyState');
         const optimizeBtn = document.getElementById('optimizeBtn');
-        const toggleSwitch = document.getElementById('toggleCot');
-        const cotCheckbox = document.getElementById('chainOfThought');
         
         
-        // Toggle switch
-        toggleSwitch.addEventListener('click', () => {
-            toggleSwitch.classList.toggle('active');
-            cotCheckbox.checked = !cotCheckbox.checked;
-        });
         
         // Form submission
         form.addEventListener('submit', async (e) => {
@@ -578,7 +560,6 @@
                 targetModel: formData.get('model'),
                 optimizationLevel: formData.get('level'),
                 outputFormat: formData.get('outputFormat'),
-                chainOfThought: formData.get('chainOfThought') === 'on'
             };
             
             // Show loading state

--- a/packages/ui/src/components/PromptForm/PromptForm.tsx
+++ b/packages/ui/src/components/PromptForm/PromptForm.tsx
@@ -23,7 +23,6 @@ export function PromptForm({ onSubmit, isLoading, error, progress = 0, stage }: 
   const [outputFormat, setOutputFormat] = useLocalStorage('promptdial-format', 'markdown')
   const [taskType] = useState<string | undefined>(undefined)
   const [validationError, setValidationError] = useState<string>('')
-  const [chainOfThought, setChainOfThought] = useState(false)
   const [showAdvanced, setShowAdvanced] = useState(false)
 
   const textareaRef = useRef<HTMLTextAreaElement>(null)
@@ -70,7 +69,6 @@ export function PromptForm({ onSubmit, isLoading, error, progress = 0, stage }: 
       targetModel: model,
       optimizationLevel: level,
       ...(taskType && taskType !== 'undefined' && { taskType }),
-      ...(chainOfThought && { chainOfThought }),
     }
 
     onSubmit(request)
@@ -197,24 +195,6 @@ export function PromptForm({ onSubmit, isLoading, error, progress = 0, stage }: 
         </div>
       )}
 
-      {/* Toggle Switch - Only show when Advanced is open */}
-      {showAdvanced && (
-        <div className={styles.toggleGroup}>
-          <div className={styles.toggleLabel}>
-            <span>Chain-of-Thought</span>
-            <span className={styles.toggleBadge}>Advanced</span>
-          </div>
-          <button
-            type="button"
-            className={`${styles.toggleSwitch} ${chainOfThought ? styles.active : ''}`}
-            onClick={() => setChainOfThought(!chainOfThought)}
-            aria-pressed={chainOfThought}
-            aria-label="Toggle chain of thought"
-          >
-            <span className={styles.toggleSlider}></span>
-          </button>
-        </div>
-      )}
 
       {/* Error Message */}
       {displayError && (

--- a/test-ui.html
+++ b/test-ui.html
@@ -29,7 +29,6 @@
             <li>Target AI Model Provider dropdown</li>
             <li><strong>Optimization Level dropdown</strong> (NEW - replaces tabs)</li>
             <li>Output Format dropdown</li>
-            <li>Chain-of-Thought toggle</li>
             <li>Refine Prompt button</li>
         </ul>
     </div>


### PR DESCRIPTION
## Summary

Remove the manual Chain-of-Thought toggle from the UI since the system now automatically selects CoT techniques based on task classification. This simplifies the user interface while maintaining full CoT functionality through intelligent automatic selection.

## Changes Made

- **React PromptForm**: Removed `chainOfThought` state variable and toggle UI components
- **HTML UI**: Removed CoT toggle elements and related JavaScript event handlers
- **Test Documentation**: Updated to reflect removed toggle
- **Request Object**: Removed `chainOfThought` parameter from optimization requests

## Why This Change?

Based on analysis of the codebase, the Chain-of-Thought functionality is automatically handled by:

- The **classifier service** (`packages/classifier/src/index.ts`) automatically maps analytical/critical tasks to CoT techniques
- The system intelligently selects between `FewShotCoTTechnique` and `IRCoTTechnique` based on task requirements
- Manual toggle was redundant since optimal CoT selection happens under the hood

## Benefits

- **Simplified UI**: Removes unnecessary user decision point
- **Better UX**: Users don't need to understand when to enable CoT
- **Consistent Results**: System makes optimal CoT decisions automatically
- **Maintained Functionality**: All CoT capabilities remain fully available

## Test Plan

- [x] UI builds successfully
- [x] Development server starts without errors
- [x] No TypeScript compilation errors in modified components
- [x] Chain-of-thought techniques still work automatically via classifier

🤖 Generated with [Claude Code](https://claude.ai/code)