### PR TITLE
fix: Clarify UI startup message and correct proxy configuration

### DIFF
--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -532,7 +532,8 @@ if (process.env.NODE_ENV !== 'test') {
 ================================ 
 ✅ Server: http://localhost:${PORT}
 ✅ API: http://localhost:${PORT}/api/optimize
-✅ UI: http://localhost:${PORT}
+✅ Basic UI: http://localhost:${PORT}
+💡 For advanced UI, run: npm run start:ui (port 5173)
 
 ${getOptimizationMode()}
 

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:3001',
+        target: 'http://localhost:3000',
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Summary
- Updated server startup message to distinguish between basic and advanced UI options
- Fixed UI proxy configuration to correctly point to API server on port 3000
- Added helpful hint about running the React UI separately

## Changes
1. **Server startup message improvements**:
   - Changed "UI" to "Basic UI" to clarify that the server provides a simple HTML interface
   - Added a helpful message: "💡 For advanced UI, run: npm run start:ui (port 5173)"
   - This helps users understand they have two UI options available

2. **Fixed proxy configuration**:
   - Updated `packages/ui/vite.config.ts` to proxy API calls to port 3000 (not 3001)
   - This ensures the React UI can correctly communicate with the API server

## Test plan
- [x] Start the server with `npm start` and verify the new startup message appears
- [x] Confirm the basic UI loads at http://localhost:3000
- [x] Run `npm run start:ui` and verify the React UI can make API calls successfully
- [x] Test API optimization endpoint works from both UIs

🤖 Generated with [Claude Code](https://claude.ai/code)