### PR TITLE
fix: resolve timeout issue when no API keys are configured

### DIFF
--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -88,7 +88,7 @@ app.get('/api/optimize/stream', async (req, res) => {
     const promptDial = new PromptDial({
       autoValidate: true,
       sortByQuality: true,
-      useAI: true,
+      useAI: hasAPIKeys,
     })
 
     // Check for real API keys before optimization


### PR DESCRIPTION
## Summary

Fixes a critical timeout issue where the system was trying to use AI optimization even when no API keys were configured, causing 60-second timeouts for all optimization requests.

## Problem

- Users without API keys were experiencing 60-second timeouts when trying to optimize prompts
- The server was hardcoded to use `useAI: true` regardless of API key availability
- This caused the system to attempt AI optimization and fail/timeout instead of falling back to fast template-based optimization

## Solution

- Changed `useAI: true` to `useAI: hasAPIKeys` in the server configuration
- Now the system correctly detects API key availability and chooses the appropriate optimization method:
  - **With API keys**: Uses AI-powered optimization 
  - **Without API keys**: Uses fast template-based optimization

## Test Plan

- [x] Verified server starts correctly with and without API keys
- [x] Confirmed optimization requests complete quickly when no API keys are present
- [x] Confirmed AI optimization still works when API keys are available

## Files Changed

- `packages/core/src/server.ts`: Updated PromptDial configuration to use `hasAPIKeys` flag

🤖 Generated with [Claude Code](https://claude.ai/code)